### PR TITLE
Revert css keyframe names

### DIFF
--- a/src/components/biscuit/styles/bakedBiscuit.css
+++ b/src/components/biscuit/styles/bakedBiscuit.css
@@ -1,11 +1,11 @@
 .bakedBiscuit {
   animation-duration: 4s, 1s, 0s;
   animation-delay: 0s, 4s, 5s;
-  animation-name: conveyor, drop, disappear;
+  animation-name: conveyorBakedBiscuit, dropBakedBiscuit, disappearBakedBiscuit;
   animation-fill-mode: forwards;
 }
 
-@keyframes conveyor {
+@keyframes conveyorBakedBiscuit {
   from {
     margin-left: 0%;
   }
@@ -15,7 +15,7 @@
   }
 }
 
-@keyframes drop {
+@keyframes dropBakedBiscuit {
   from {
     margin-left: 14%;
     margin-top: 5%;
@@ -27,7 +27,7 @@
   }
 }
 
-@keyframes disappear {
+@keyframes disappearBakedBiscuit {
   from {
     margin-left: 14%;
     margin-top: 5%;

--- a/src/components/biscuit/styles/biscuit.css
+++ b/src/components/biscuit/styles/biscuit.css
@@ -1,11 +1,11 @@
 .biscuit {
   animation-duration: 5s, 0s;
   animation-delay: 0s, 5s;
-  animation-name: conveyor, disappear;
+  animation-name: conveyorBiscuit, disappearBiscuit;
   animation-fill-mode: forwards;
 }
 
-@keyframes conveyor {
+@keyframes conveyorBiscuit {
   from {
     margin-left: 0%;
   }
@@ -15,7 +15,7 @@
   }
 }
 
-@keyframes disappear {
+@keyframes disappearBiscuit {
   from {
     margin-left: 25%;
   }

--- a/src/components/biscuit/styles/dough.css
+++ b/src/components/biscuit/styles/dough.css
@@ -1,11 +1,11 @@
 .dough {
   animation-duration: 2s, 4s, 1s, 0s;
   animation-delay: 0s, 2s, 6s, 7s;
-  animation-name: drop, conveyor, wait, disappear;
+  animation-name: dropDough, conveyorDough, wait, disappearDough;
   animation-fill-mode: forwards;
 }
 
-@keyframes drop {
+@keyframes dropDough {
   from {
     margin-top: 0%;
   }
@@ -15,7 +15,7 @@
   }
 }
 
-@keyframes conveyor {
+@keyframes conveyorDough {
   from {
     margin-left: 0%;
     margin-top: 5%;
@@ -39,7 +39,7 @@
   }
 }
 
-@keyframes disappear {
+@keyframes disappearDough {
   from {
     margin-left: 9%;
     margin-top: 5%;


### PR DESCRIPTION
When the same name is used for different keyframes, only one of them is used which causes unwanted behaviour.