### PR TITLE
Move Stamper in front of Biscuit

### DIFF
--- a/src/components/stamper/stamper.js
+++ b/src/components/stamper/stamper.js
@@ -11,6 +11,7 @@ const Stamper = ({ stamp, animationState }) => {
         height: "50px",
         width: "100px",
         WebkitAnimationPlayState: animationState,
+        zIndex: "1"
       }}
     >
       Stamper


### PR DESCRIPTION
- Hide Dough and Biscuit behind Stamper to better imitate being stamped

<img width="1068" alt="Screenshot 2022-01-10 at 9 17 02" src="https://user-images.githubusercontent.com/36369561/148729984-c73ecd73-5f22-4642-917f-32e559e6dde5.png">
<img width="1067" alt="Screenshot 2022-01-10 at 9 17 24" src="https://user-images.githubusercontent.com/36369561/148729992-d11e4720-01c8-4071-be05-c0d08a6b3065.png">

