### PR TITLE
Move Biscuit behind Container

### DIFF
--- a/src/components/biscuit/bakedBiscuit.js
+++ b/src/components/biscuit/bakedBiscuit.js
@@ -19,6 +19,7 @@ const BakedBiscuit = ({ state, onBaked }) => {
         position: "absolute",
         WebkitAnimationPlayState: state,
         paddingLeft: "25px",
+        zIndex: "-1"
       }}
     >
       Baked


### PR DESCRIPTION
- Hide Biscuit behind Container to imitate going inside

<img width="1061" alt="Screenshot 2022-01-10 at 9 34 41" src="https://user-images.githubusercontent.com/36369561/148731442-06eb8b7f-58ad-4316-a8c9-ebafad77165e.png">

