### PR TITLE
Delay motor shut down when conveyor is clearing

### DIFF
--- a/src/components/motor.js
+++ b/src/components/motor.js
@@ -14,7 +14,7 @@ const Motor = ({
     if (motorWorking && machineState === "Off") {
       setTimeout(() => {
         setMotorWorking(false);
-      }, 15000);
+      }, 17000);
     }
   }, [machineState, motorWorking, setMotorWorking]);
 


### PR DESCRIPTION
- Delay motor shut down so that the baked biscuit has enough time to drop in the container after conveyor is cleaned