### PR TITLE
Move testing-library to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "5.14.1",
-    "@testing-library/react": "12.0.0",
-    "@testing-library/user-event": "13.2.1",
     "bootstrap": "5.1.3",
     "react": "17.0.2",
     "react-bootstrap": "2.0.4",
@@ -44,6 +41,9 @@
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "4.0.0",
     "npm-run-all": "4.1.5",
-    "prettier": "2.4.1"
+    "prettier": "2.4.1",
+    "@testing-library/jest-dom": "5.14.1",
+    "@testing-library/react": "12.0.0",
+    "@testing-library/user-event": "13.2.1"
   }
 }


### PR DESCRIPTION
`@testing-library/jest-dom` `@testing-library/react` and `@testing-library/user-event` are only used during development