### PR TITLE
Add switch for faster heating

### DIFF
--- a/src/components/__tests__/__snapshots__/machine.test.js.snap
+++ b/src/components/__tests__/__snapshots__/machine.test.js.snap
@@ -124,6 +124,28 @@ exports[`<Machine /> should match snapshot 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="row"
+    >
+      <form
+        class=""
+      >
+        <div
+          class="form-check form-switch"
+        >
+          <input
+            class="form-check-input"
+            type="checkbox"
+          />
+          <label
+            class="form-check-label"
+            title=""
+          >
+            Faster heating
+          </label>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/boostSwitch.js
+++ b/src/components/boostSwitch.js
@@ -1,0 +1,9 @@
+import { Form } from "react-bootstrap";
+
+const BoostSwitch = () => (
+  <Form>
+    <Form.Check type="switch" label="Faster heating" />
+  </Form>
+);
+
+export default BoostSwitch;

--- a/src/components/boostSwitch.js
+++ b/src/components/boostSwitch.js
@@ -1,8 +1,8 @@
 import { Form } from "react-bootstrap";
 
-const BoostSwitch = () => (
+const BoostSwitch = ({ onChange }) => (
   <Form>
-    <Form.Check type="switch" label="Faster heating" />
+    <Form.Check type="switch" label="Faster heating" onChange={onChange} />
   </Form>
 );
 

--- a/src/components/machine.js
+++ b/src/components/machine.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Container, Row, Col } from "react-bootstrap";
 
 import BiscuitLifecycle from "./biscuit/biscuitLifecycle.js";
+import BoostSwitch from "./boostSwitch.js";
 import BiscuitContainer from "./container.js";
 import Conveyor from "./conveyor.js";
 import Extruder from "./extruder.js";
@@ -75,6 +76,10 @@ const Machine = () => {
         <Col md={{ span: 2, offset: 2 }}>
           <Switch onChange={setState} />
         </Col>
+      </Row>
+
+      <Row>
+        <BoostSwitch />
       </Row>
     </Container>
   );

--- a/src/components/machine.js
+++ b/src/components/machine.js
@@ -36,7 +36,11 @@ const Machine = () => {
         </Col>
 
         <Col md={{ span: 2, offset: 1 }}>
-          <Oven machineState={state} setMotorWorking={setMotorWorking} />
+          <Oven
+            machineState={state}
+            setMotorWorking={setMotorWorking}
+            fasterHeating={fasterHeating}
+          />
         </Col>
       </Row>
 

--- a/src/components/machine.js
+++ b/src/components/machine.js
@@ -80,7 +80,7 @@ const Machine = () => {
       </Row>
 
       <Row>
-        <BoostSwitch />
+        <BoostSwitch onChange={() => setFasterHeating(!fasterHeating)} />
       </Row>
     </Container>
   );

--- a/src/components/machine.js
+++ b/src/components/machine.js
@@ -17,6 +17,7 @@ const Machine = () => {
   const [motorWorking, setMotorWorking] = useState(false);
   const [stamping, setStamping] = useState(false);
   const [animationState, setAnimationState] = useState("running");
+  const [fasterHeating, setFasterHeating] = useState(false);
 
   useEffect(() => {
     if (state === "Paused") setAnimationState("paused");

--- a/src/components/oven.js
+++ b/src/components/oven.js
@@ -1,9 +1,18 @@
 import { useEffect, useState } from "react";
 
-const Oven = ({ machineState, setMotorWorking }) => {
+const Oven = ({ machineState, setMotorWorking, fasterHeating }) => {
   const [ovenDegrees, setOvenDegrees] = useState(0);
   const [heatingElement, setHeatingElement] = useState(false);
   const [color, setColor] = useState("");
+  const [heatingTimeout, setHeatingTimeout] = useState(1000);
+
+  useEffect(() => {
+    if (fasterHeating) {
+      setHeatingTimeout(100);
+    } else {
+      setHeatingTimeout(1000);
+    }
+  }, [fasterHeating]);
 
   useEffect(() => {
     if (
@@ -23,7 +32,7 @@ const Oven = ({ machineState, setMotorWorking }) => {
     if (heatingElement) {
       timer = setTimeout(() => {
         if (ovenDegrees < 240) setOvenDegrees(ovenDegrees + 1);
-      }, 1000);
+      }, heatingTimeout);
     } else {
       timer = setTimeout(() => {
         if (ovenDegrees > 0) setOvenDegrees(ovenDegrees - 1);
@@ -31,7 +40,7 @@ const Oven = ({ machineState, setMotorWorking }) => {
     }
 
     return () => clearTimeout(timer);
-  }, [heatingElement, ovenDegrees]);
+  }, [heatingElement, ovenDegrees, heatingTimeout]);
 
   useEffect(() => {
     if (ovenDegrees >= 220 && machineState === "On") {


### PR DESCRIPTION
When the switch for `Faster heating` is `On` the Timeout for increasing the oven degrees is 100ms.
The default is 1000ms to which turning the switch `Off` goes back to.

![Screenshot_1](https://user-images.githubusercontent.com/36369561/152534266-c53628db-4fc1-43a2-9e92-5f1b59bf90e1.png)
